### PR TITLE
Validate label names correctly

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus.AspCore/TextFormatActionResult.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.AspCore/TextFormatActionResult.cs
@@ -25,7 +25,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus.AspCore
             context.HttpContext.Response.StatusCode = 200;
             context.HttpContext.Response.Headers["Content-Type"] = "text/plain; version=0.0.4; charset=utf-8";
 
-            using (var writer = new StreamWriter(context.HttpContext.Response.Body, PrometheusConventions.UTF8, 128, true))
+            using (var writer = new StreamWriter(context.HttpContext.Response.Body, PrometheusConventions.PrometheusEncoding, 128, true))
             {
                 writer.NewLine = "\n";
 

--- a/Nexogen.Libraries.Metrics.Prometheus/Counter.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/Counter.cs
@@ -26,7 +26,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public Counter(string help, string name, string[] labelNames, string[] labels)
         {
-            if (!NameRegex.IsMatch(name))
+            if (!IsValidName(name))
             {
                 throw new ArgumentException($"Invalid metric name: {name}");
             }

--- a/Nexogen.Libraries.Metrics.Prometheus/Histogram.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/Histogram.cs
@@ -21,7 +21,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public Histogram(IBucket[] buckets, string help, string name, string[] labelNames, string[] labels)
         {
-            if (!NameRegex.IsMatch(name))
+            if (!IsValidName(name))
             {
                 throw new ArgumentException($"Invalid metric name: {name}");
             }

--- a/Nexogen.Libraries.Metrics.Prometheus/LabelledCounterBuilder.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/LabelledCounterBuilder.cs
@@ -30,7 +30,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledCounterBuilder LabelNames(params string[] labelNames)
         {
-            if (labelNames.Any(l => !NameRegex.IsMatch(l)))
+            if (labelNames.Any(l => !IsValidLabel(l)))
             {
                 throw new ArgumentException("Label names must follow prometheus conventions");
             }
@@ -42,7 +42,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledCounterBuilder Name(string name)
         {
-            if (!NameRegex.IsMatch(name))
+            if (!IsValidName(name))
             {
                 throw new ArgumentException("Name must follow prometheus conventions");
             }

--- a/Nexogen.Libraries.Metrics.Prometheus/LabelledGaugeBuilder.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/LabelledGaugeBuilder.cs
@@ -30,7 +30,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledGaugeBuilder LabelNames(params string[] labelNames)
         {
-            if (labelNames.Any(l => !NameRegex.IsMatch(l)))
+            if (labelNames.Any(l => !IsValidLabel(l)))
             {
                 throw new ArgumentException("Label names must follow prometheus conventions");
             }
@@ -42,7 +42,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledGaugeBuilder Name(string name)
         {
-            if (!NameRegex.IsMatch(name))
+            if (!IsValidName(name))
             {
                 throw new ArgumentException("Name must follow prometheus conventions");
             }

--- a/Nexogen.Libraries.Metrics.Prometheus/LabelledHistogramBuilder.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/LabelledHistogramBuilder.cs
@@ -30,7 +30,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledHistogramBuilder LabelNames(params string[] labelNames)
         {
-            if (labelNames.Any(l => !NameRegex.IsMatch(l)))
+            if (labelNames.Any(l => !IsValidLabel(l)))
             {
                 throw new ArgumentException("Label names must follow prometheus conventions");
             }
@@ -42,7 +42,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public ILabelledHistogramBuilder Name(string name)
         {
-            if (!NameRegex.IsMatch(name))
+            if (!IsValidName(name))
             {
                 throw new ArgumentException("Name must follow prometheus conventions");
             }

--- a/Nexogen.Libraries.Metrics.Prometheus/Prometheus.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/Prometheus.cs
@@ -10,8 +10,10 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 {
     public static class PrometheusConventions
     {
-        public static readonly Regex NameRegex = new Regex("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
-        public static readonly Encoding UTF8 = new UTF8Encoding(false);
+        private static readonly Regex NameRegex = new Regex("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
+        private static readonly Regex LabelRegex = new Regex("^[a-zA-Z_][a-zA-Z0-9_]*$");
+
+        public static readonly Encoding PrometheusEncoding = new UTF8Encoding(false);
 
         public static string BuildLabels(string[] labelNames, string[] labels)
         {
@@ -74,6 +76,11 @@ namespace Nexogen.Libraries.Metrics.Prometheus
         public static bool IsValidName(string name)
         {
             return NameRegex.IsMatch(name);
+        }
+
+        public static bool IsValidLabel(string label)
+        {
+            return !label.StartsWith("__") && LabelRegex.IsMatch(label);
         }
 
         public static bool AreValidHistogramNames(IEnumerable<string> names)

--- a/Nexogen.Libraries.Metrics.Prometheus/PrometheusRegistry.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/PrometheusRegistry.cs
@@ -25,7 +25,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus
                 coreclrExporter.Collect();
             }
 
-            using (var writer = new StreamWriter(output, PrometheusConventions.UTF8, 4096, true))
+            using (var writer = new StreamWriter(output, PrometheusConventions.PrometheusEncoding, 4096, true))
             {
                 writer.NewLine = "\n";
 

--- a/Nexogen.Libraries.Metrics.UnitTests/Prometheus/PrometheusTest.cs
+++ b/Nexogen.Libraries.Metrics.UnitTests/Prometheus/PrometheusTest.cs
@@ -14,6 +14,41 @@ namespace Nexogen.Libraries.Metrics.UnitTests.Prometheus
         }
 
         [Theory]
+        [InlineData("name")]
+        [InlineData("the_name")]
+        [InlineData(":name:")]
+        [InlineData("name14")]
+        [InlineData("__name_")]
+        [InlineData("NamE")]
+        public void IsValidName_should_return_true_for_valid_names(string name)
+        {
+            Assert.True(PrometheusConventions.IsValidName(name));
+        }
+
+        [Theory]
+        [InlineData("9label")]
+        [InlineData("")]
+        [InlineData("this:isnotvalid")]
+        [InlineData(":label")]
+        [InlineData("__label")]
+        [InlineData("___label")]
+        public void IsValidLabel_should_return_false_for_invalid_labels(string label)
+        {
+            Assert.False(PrometheusConventions.IsValidLabel(label));
+        }
+
+        [Theory]
+        [InlineData("name")]
+        [InlineData("the_name")]
+        [InlineData("name14")]
+        [InlineData("_name_")]
+        [InlineData("LabeL")]
+        public void IsValidLabel_should_return_true_for_valid_labels(string label)
+        {
+            Assert.True(PrometheusConventions.IsValidName(label));
+        }
+
+        [Theory]
         [InlineData("le")]
         public void IsValidHistogramName_should_return_false_for_invalid_names(string name)
         {


### PR DESCRIPTION
Use the proper regex for label names and don't expose regex directly, but use a validation function.