### PR TITLE
Add instance label and default labels to PGW endpoint

### DIFF
--- a/Nexogen.Libraries.Metrics.Example/Program.cs
+++ b/Nexogen.Libraries.Metrics.Example/Program.cs
@@ -43,7 +43,12 @@ namespace Nexogen.Libraries.Metrics.Example
                 .LabelNames("solver")
                 .Register();
 
-            var pgw = new PushGateway(new Uri("http://127.0.0.1:9091"));
+
+            var pgw = new PushGateway(
+                new Uri("http://127.0.0.1:9091"), 
+                "example_app",
+                new List<Tuple<string, string>> {Tuple.Create("environment", "test")}
+                );
 
             Task.Run(async () =>
             {


### PR DESCRIPTION
PushGateway endpoint allows us to add instance and an arbitrary number of labels by using an endpoint in the form of:
```
/metrics/job/<JOBNAME>{/<LABEL_NAME>/<LABEL_VALUE>}
```
This addresses https://github.com/nexogen-international/Nexogen.Libraries.Metrics/issues/6 and https://github.com/nexogen-international/Nexogen.Libraries.Metrics/issues/7

How it looks like in Prometheus after scraping PushGateway:

![prometheus](https://user-images.githubusercontent.com/5790049/31120054-9ea67f92-a88f-11e7-9534-73078696d056.png)

