### PR TITLE
Fixed escaping of backslashes

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus/Prometheus.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/Prometheus.cs
@@ -105,15 +105,15 @@ namespace Nexogen.Libraries.Metrics.Prometheus
 
         public static string EscapeLabel(string label)
         {
-            return label.Replace("\n", @"\n")
-                        .Replace("\\", @"\")
+            return label.Replace("\\", @"\\")
+                        .Replace("\n", @"\n")
                         .Replace("\"", @"\""");
         }
 
         public static string EscapeHelp(string help)
         {
-            return help.Replace("\n", @"\n")
-                       .Replace("\\", @"\");
+            return help.Replace("\\", @"\\")
+                       .Replace("\n", @"\n");
         }
     }
 }

--- a/Nexogen.Libraries.Metrics.UnitTests/Prometheus/PrometheusTest.cs
+++ b/Nexogen.Libraries.Metrics.UnitTests/Prometheus/PrometheusTest.cs
@@ -75,7 +75,7 @@ namespace Nexogen.Libraries.Metrics.UnitTests.Prometheus
         public void Help_text_is_properly_escaped()
         {
             Assert.Equal(@"help\nnewline", PrometheusConventions.EscapeHelp("help\nnewline"));
-            Assert.Equal(@"a\b", PrometheusConventions.EscapeHelp("a\\b"));
+            Assert.Equal(@"a\\b", PrometheusConventions.EscapeHelp("a\\b"));
             Assert.Equal(@"it's ""OK""", PrometheusConventions.EscapeHelp("it's \"OK\""));
         }
 
@@ -83,7 +83,7 @@ namespace Nexogen.Libraries.Metrics.UnitTests.Prometheus
         public void Label_text_is_properly_escaped()
         {
             Assert.Equal(@"help\nnewline", PrometheusConventions.EscapeLabel("help\nnewline"));
-            Assert.Equal(@"a\b", PrometheusConventions.EscapeLabel("a\\b"));
+            Assert.Equal(@"a\\b", PrometheusConventions.EscapeLabel("a\\b"));
             Assert.Equal(@"it's not \""OK\""", PrometheusConventions.EscapeLabel("it's not \"OK\""));
         }
     }


### PR DESCRIPTION
A backslash in label values and help docstrings needs to be escaped as \\\\