### PR TITLE
extend UsePrometheus() with optional bool parameter collectAspMetrics

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusExtensions.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusExtensions.cs
@@ -44,11 +44,14 @@ namespace Nexogen.Libraries.Metrics.Prometheus.AspCore
         /// Add Prometheus Metrics support to the application.
         /// </summary>
         /// <param name="builder"></param>
+        /// <param name="collectAspMetrics">to avoid the collection of ASP request metrics (URLs and timings) pass false</param>
         /// <returns></returns>
-        public static IApplicationBuilder UsePrometheus(this IApplicationBuilder builder)
+        public static IApplicationBuilder UsePrometheus(this IApplicationBuilder builder, bool collectAspMetrics = true)
         {
-            return builder.UseMiddleware<CollectMetricsMiddleware>()
-                .Map("/metrics", cfg =>
+            if (collectAspMetrics)
+                builder.UseMiddleware<CollectMetricsMiddleware>();
+
+            return builder.Map("/metrics", cfg =>
                 {
                     cfg.UseMiddleware<ServeMetricsMiddleware>();
                 });


### PR DESCRIPTION
true: collect ASP request URLs and timings (as before)
false: don't collect anything (only what you explicitly log)
Default value true to be backward compatible.
