### PR TITLE
Make collecting HTTP metrics optional

### DIFF
--- a/Nexogen.Libraries.Metrics.ExampleWeb/Startup.cs
+++ b/Nexogen.Libraries.Metrics.ExampleWeb/Startup.cs
@@ -35,7 +35,7 @@ namespace Nexogen.Libraries.Metrics.ExampleWeb
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            app.UsePrometheus();
+            app.UsePrometheus(options => options.CollectHttpMetrics());
             app.UseMvc();
         }
     }

--- a/Nexogen.Libraries.Metrics.Prometheus.AspCore/IPrometheusOptions.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.AspCore/IPrometheusOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.AspCore
+{
+    /// <summary>
+    /// Options passed to Prometheus
+    /// </summary>
+    public interface IPrometheusOptions
+    {
+        /// <summary>
+        /// Collect HTTP Statistics.
+        /// </summary>
+        IPrometheusOptions CollectHttpMetrics();
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusExtensions.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusExtensions.cs
@@ -43,15 +43,18 @@ namespace Nexogen.Libraries.Metrics.Prometheus.AspCore
         /// <summary>
         /// Add Prometheus Metrics support to the application.
         /// </summary>
-        /// <param name="builder"></param>
+        /// 
+        /// <param name="builder">The IApplicationBuilder instance.</param>
+        /// <param name="options">Options to tune metrics behaviour.</param>
         /// <returns></returns>
-        public static IApplicationBuilder UsePrometheus(this IApplicationBuilder builder)
+        public static IApplicationBuilder UsePrometheus(this IApplicationBuilder builder, Action<IPrometheusOptions> options = null)
         {
-            return builder.UseMiddleware<CollectMetricsMiddleware>()
-                .Map("/metrics", cfg =>
-                {
-                    cfg.UseMiddleware<ServeMetricsMiddleware>();
-                });
+            options?.Invoke(new PrometheusOptions(builder));
+
+            return builder.Map("/metrics", cfg =>
+            {
+                cfg.UseMiddleware<ServeMetricsMiddleware>();
+            });
         }
     }
 }

--- a/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusOptions.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.AspCore/PrometheusOptions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Builder;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.AspCore
+{
+    internal class PrometheusOptions : IPrometheusOptions
+    {
+        private readonly IApplicationBuilder builder;
+
+        public PrometheusOptions(IApplicationBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        public IPrometheusOptions CollectHttpMetrics()
+        {
+            builder.UseMiddleware<CollectMetricsMiddleware>();
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
- Add support for enabling http metrics collection through an option action
- Disable collecting metrics by default
- Workaround for #15