### PR TITLE
Add ReplaceValue to LabeledGauge. 

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus/LabelledGauge.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus/LabelledGauge.cs
@@ -36,26 +36,26 @@ namespace Nexogen.Libraries.Metrics.Prometheus
                 key => new Gauge(help, name, labelNames, key));
         }
 
-        public void ReplaceValues(IDictionary<string[], double> newValues)
+        public void ReplaceMetricValues(IDictionary<string[], double> newMetricValues)
         {
-            if (newValues == null)
+            if (newMetricValues == null)
             {
-                throw new ArgumentNullException(nameof(newValues));
+                throw new ArgumentNullException(nameof(newMetricValues));
             }
 
-            if (newValues.Keys.Any(x => x.Length != labelNames.Length))
+            if (newMetricValues.Keys.Any(x => x.Length != labelNames.Length))
             {
                 throw new ArgumentException($"The number of labels should be equal to the number of label names for all value");
             }
 
             var newChildren = new ConcurrentDictionary<string[], Gauge>(new StringArrayComparer());
 
-            foreach (var newValue in newValues)
+            foreach (var newMetricValue in newMetricValues)
             {
-                var gauge = newChildren.GetOrAdd(newValue.Key.Select(l => EscapeLabel(l)).ToArray(),
+                var gauge = newChildren.GetOrAdd(newMetricValue.Key.Select(l => EscapeLabel(l)).ToArray(),
                     key => new Gauge(help, name, labelNames, key));
 
-                gauge.Value = newValue.Value;
+                gauge.Value = newMetricValue.Value;
             }
 
             this.children = newChildren;

--- a/Nexogen.Libraries.Metrics.UnitTests/Prometheus/ExposeTest.cs
+++ b/Nexogen.Libraries.Metrics.UnitTests/Prometheus/ExposeTest.cs
@@ -361,7 +361,7 @@ namespace Nexogen.Libraries.Metrics.UnitTests.Prometheus
             gauge.Labels("GET").Value = 974;
             gauge.Labels("POST").Value = 823;
 
-            gauge.ReplaceValues(new Dictionary<string[], double>()
+            gauge.ReplaceMetricValues(new Dictionary<string[], double>()
             {
                 { new[] { "POST" }, 151 },
                 { new[] { "HEAD" }, 673 },

--- a/Nexogen.Libraries.Metrics/ILabelledGauge.cs
+++ b/Nexogen.Libraries.Metrics/ILabelledGauge.cs
@@ -1,4 +1,7 @@
-﻿namespace Nexogen.Libraries.Metrics
+﻿using System;
+using System.Collections.Generic;
+
+namespace Nexogen.Libraries.Metrics
 {
     /// <summary>
     /// A gauge with labels. Labels can be used to differentiate
@@ -17,10 +20,24 @@
         /// <summary>
         /// Assign value to the configured labels.
         /// The count of values should be the same as the count of labels.
-        /// A new gauge is created for each tuple of lable values.
+        /// A new gauge is created for each tuple of label values.
         /// </summary>
         /// <param name="labels">The label values</param>
         /// <returns>The gauge unique to the given values</returns>
+        /// <exception cref="ArgumentException">The number of label names aren't equal to the defined labels.</exception>
         IGauge Labels(params string[] labels);
+
+
+        /// <summary>
+        /// Replace the current values with a new value set. 
+        /// This method can be useful if you want to update the 
+        /// whole set and deprecate old values in the same time. 
+        /// The update operation happens as an atomic operation.
+        /// </summary>
+        /// <param name="newValues">the new values with labels. </param>
+        /// <returns>Nothing.</returns>
+        /// <exception cref="ArgumentNullException">if newValues is null</exception>
+        /// <exception cref="ArgumentException">if label count doesn't match with the defined labels.</exception>
+        void ReplaceValues(IDictionary<string[], double> newValues);
     }
 }

--- a/Nexogen.Libraries.Metrics/ILabelledGauge.cs
+++ b/Nexogen.Libraries.Metrics/ILabelledGauge.cs
@@ -34,10 +34,10 @@ namespace Nexogen.Libraries.Metrics
         /// whole set and deprecate old values in the same time. 
         /// The update operation happens as an atomic operation.
         /// </summary>
-        /// <param name="newValues">the new values with labels. </param>
+        /// <param name="newMetricValues">the new values with labels. </param>
         /// <returns>Nothing.</returns>
         /// <exception cref="ArgumentNullException">if newValues is null</exception>
         /// <exception cref="ArgumentException">if label count doesn't match with the defined labels.</exception>
-        void ReplaceValues(IDictionary<string[], double> newValues);
+        void ReplaceMetricValues(IDictionary<string[], double> newMetricValues);
     }
 }


### PR DESCRIPTION
Currently there is no way to remove a metric with a specific label (see #31). This pull request solve the the use case when you need to update metrics and remove obsoleted ones atomically. 