### PR TITLE
Add gRPC metrics interceptors

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/ClientMetrics.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/ClientMetrics.cs
@@ -1,0 +1,15 @@
+﻿namespace Nexogen.Libraries.Metrics.Prometheus.Grpc
+{
+    /// <summary>
+    /// Metrics for gRPC clients.
+    /// </summary>
+    public class ClientMetrics : MetricsBase
+    {
+        /// <summary>
+        /// Registers gRPC client metrics.
+        /// </summary>
+        /// <param name="metrics">Builder to register the metrics in.</param>
+        public ClientMetrics(IMetrics metrics) : base(metrics, kind: "client")
+        {}
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/ClientMetricsInterceptor.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/ClientMetricsInterceptor.cs
@@ -1,0 +1,112 @@
+﻿using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Nexogen.Libraries.Metrics.Prometheus.Grpc.Internal;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.Grpc
+{
+    /// <summary>
+    /// gRPC client interceptor for collecting Prometheus metrics.
+    /// </summary>
+    public class ClientMetricsInterceptor : Interceptor
+    {
+        private ClientMetrics metrics;
+
+        /// <summary>
+        /// Creates a gRPC client interceptor for collecting Prometheus metrics.
+        /// </summary>
+        public ClientMetricsInterceptor(ClientMetrics metrics)
+        {
+            this.metrics = metrics;
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.Unary, context.Method);
+            try
+            {
+                var response = await continuation(request, context);
+                metrics.Handled(MethodType.Unary, context.Method, StatusCode.OK);
+                return response;
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.Unary, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.Unary, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context, ClientStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.ClientStreaming, context.Method);
+            try
+            {
+                var response = await continuation(
+                    new CountingStreamReader<TRequest>(requestStream, () => metrics.StreamMsgSent(MethodType.ClientStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.ClientStreaming, context.Method, StatusCode.OK);
+                return response;
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.ClientStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.ClientStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.ServerStreaming, context.Method);
+            try
+            {
+                await continuation(request,
+                    new CountingStreamWriter<TResponse>(responseStream, () => metrics.StreamMsgReceived(MethodType.ServerStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.ServerStreaming, context.Method, StatusCode.OK);
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.ServerStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.ServerStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.DuplexStreaming, context.Method);
+            try
+            {
+                await continuation(
+                    new CountingStreamReader<TRequest>(requestStream, () => metrics.StreamMsgSent(MethodType.DuplexStreaming, context.Method)),
+                    new CountingStreamWriter<TResponse>(responseStream, () => metrics.StreamMsgReceived(MethodType.DuplexStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, StatusCode.OK);
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/Internal/CountingStreamReader.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/Internal/CountingStreamReader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.Grpc.Internal
+{
+    internal class CountingStreamReader<T> : IAsyncStreamReader<T>
+        where T : class
+    {
+        private readonly IAsyncStreamReader<T> innerStream;
+        private readonly Action callback;
+
+        public CountingStreamReader(IAsyncStreamReader<T> innerStream, Action callback)
+        {
+            this.innerStream = innerStream;
+            this.callback = callback;
+        }
+
+        public T Current => innerStream.Current;
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            if (await innerStream.MoveNext())
+            {
+                callback();
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/Internal/CountingStreamWriter.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/Internal/CountingStreamWriter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.Grpc.Internal
+{
+    internal class CountingStreamWriter<T> : IServerStreamWriter<T> 
+    {
+        private readonly IServerStreamWriter<T> innerStream;
+        private readonly Action callback;
+
+        public CountingStreamWriter(IServerStreamWriter<T> innerStream, Action callback)
+        {
+            this.innerStream = innerStream;
+            this.callback = callback;
+        }
+
+        public WriteOptions WriteOptions
+        {
+            get => innerStream.WriteOptions;
+            set => innerStream.WriteOptions = value;
+        }
+
+        public Task WriteAsync(T message)
+        {
+            callback();
+            return innerStream.WriteAsync(message);
+        }
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/MetricsBase.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/MetricsBase.cs
@@ -1,0 +1,112 @@
+﻿using System.Linq;
+using Grpc.Core;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.Grpc
+{
+    /// <summary>
+    /// Common base class for gRPC-related metrics.
+    /// </summary>
+    public abstract class MetricsBase
+    {
+        private static readonly string[] labelNames = {"grpc_type", "grpc_service", "grpc_method"};
+        private static readonly string[] labelNamesWithCode = {"grpc_type", "grpc_service", "grpc_method", "grpc_code"};
+    
+        /// <summary>
+        /// Registers gRPC metrics.
+        /// </summary>
+        /// <param name="metrics">Builder to register the metrics in.</param>
+        /// <param name="kind">The kind of metrics: server or client.</param>
+        protected MetricsBase(IMetrics metrics, string kind)
+        {
+            started = metrics
+                .Counter()
+                .Name($"grpc_{kind}_started_total")
+                .Help($"Total number of RPCs started on the {kind}.")
+                .LabelNames(labelNames)
+                .Register();
+
+            handled = metrics
+                .Counter()
+                .Name($"grpc_{kind}_handled_total")
+                .Help($"Total number of RPCs completed on the {kind}, regardless of success or failure.")
+                .LabelNames(labelNamesWithCode)
+                .Register();
+
+            streamMsgReceived = metrics
+                .Counter()
+                .Name($"grpc_{kind}_msg_received_total")
+                .Help($"Total number of RPC stream messages received by the {kind}.")
+                .LabelNames(labelNames)
+                .Register();
+
+            streamMsgSent = metrics
+                .Counter()
+                .Name($"grpc_{kind}_msg_sent_total")
+                .Help($"Total number of gRPC stream messages sent by the {kind}.")
+                .LabelNames(labelNames)
+                .Register();
+        }
+
+        private readonly ILabelledCounter started;
+
+        /// <summary>
+        /// Call when an RPC started.
+        /// </summary>
+        /// <param name="type">The type of RPC method.</param>
+        /// <param name="method">The full gRPC method name (including the service name).</param>
+        public void Started(MethodType type, string method)
+            => started.Labels(GetLabels(type, method)).Increment();
+
+        private readonly ILabelledCounter handled;
+
+        /// <summary>
+        /// Call when an RPC completed, regardless of success or failure.
+        /// </summary>
+        /// <param name="type">The type of RPC method.</param>
+        /// <param name="method">The full gRPC method name (including the service name).</param>
+        /// <param name="statusCode">The gRPC status code.</param>
+        public void Handled(MethodType type, string method, StatusCode statusCode)
+            => handled.Labels(GetLabels(type, method, statusCode)).Increment();
+
+        private readonly ILabelledCounter streamMsgReceived;
+
+        /// <summary>
+        /// Call when a stream message was received.
+        /// </summary>
+        /// <param name="type">The type of RPC method.</param>
+        /// <param name="method">The full gRPC method name (including the service name).</param>
+        public void StreamMsgReceived(MethodType type, string method)
+            => streamMsgReceived.Labels(GetLabels(type, method)).Increment();
+
+        private readonly ILabelledCounter streamMsgSent;
+
+        /// <summary>
+        /// Call when a stream message was sent.
+        /// </summary>
+        /// <param name="type">The type of RPC method.</param>
+        /// <param name="method">The full gRPC method name (including the service name).</param>
+        public void StreamMsgSent(MethodType type, string method)
+            => streamMsgSent.Labels(GetLabels(type, method)).Increment();
+
+        private static string[] GetLabels(MethodType type, string method)
+        {
+            var split = method.Split('/');
+            return new[]
+            {
+                type switch
+                {
+                    MethodType.Unary => "unary",
+                    MethodType.ClientStreaming => "client_stream",
+                    MethodType.ServerStreaming => "server_stream",
+                    MethodType.DuplexStreaming => "bidi_stream",
+                    _ => "unknown"
+                },
+                split[0],
+                split[1]
+            };
+        }
+
+        private string[] GetLabels(MethodType type, string method, StatusCode statusCode)
+            => GetLabels(type, method).Append(statusCode.ToString()).ToArray();
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/Nexogen.Libraries.Metrics.Prometheus.Grpc.csproj
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/Nexogen.Libraries.Metrics.Prometheus.Grpc.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionPrefix>$(PackageVersionNumber)</VersionPrefix>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  
+    <Description>gRPC metrics collector for Nexogen Metrics API implementation for Prometheus</Description>
+    <PackageTags>Metrics;Prometheus;gRPC</PackageTags>
+    <PackageIconUrl>https://raw.githubusercontent.com/nexogen-international/Nexogen.Libraries.Metrics/master/icon.png</PackageIconUrl>
+    <Authors>Nexogen</Authors>
+    <Copyright>Nexogen 2020</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nexogen.Libraries.Metrics\Nexogen.Libraries.Metrics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.Core.Api" Version="2.28.1" />
+  </ItemGroup>
+  
+</Project>

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/ServerMetrics.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/ServerMetrics.cs
@@ -1,0 +1,15 @@
+﻿namespace Nexogen.Libraries.Metrics.Prometheus.Grpc
+{
+    /// <summary>
+    /// Metrics for gRPC servers.
+    /// </summary>
+    public class ServerMetrics : MetricsBase
+    {
+        /// <summary>
+        /// Registers gRPC server metrics.
+        /// </summary>
+        /// <param name="metrics">Builder to register the metrics in.</param>
+        public ServerMetrics(IMetrics metrics) : base(metrics, kind: "server")
+        {}
+    }
+}

--- a/Nexogen.Libraries.Metrics.Prometheus.Grpc/ServerMetricsInterceptor.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.Grpc/ServerMetricsInterceptor.cs
@@ -1,0 +1,112 @@
+﻿using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Nexogen.Libraries.Metrics.Prometheus.Grpc.Internal;
+
+namespace Nexogen.Libraries.Metrics.Prometheus.Grpc
+{
+    /// <summary>
+    /// gRPC server interceptor for collecting Prometheus metrics.
+    /// </summary>
+    public class ServerMetricsInterceptor : Interceptor
+    {
+        private ServerMetrics metrics;
+
+        /// <summary>
+        /// Creates a gRPC server interceptor for collecting Prometheus metrics.
+        /// </summary>
+        public ServerMetricsInterceptor(ServerMetrics metrics)
+        {
+            this.metrics = metrics;
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.Unary, context.Method);
+            try
+            {
+                var response = await continuation(request, context);
+                metrics.Handled(MethodType.Unary, context.Method, StatusCode.OK);
+                return response;
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.Unary, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.Unary, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context, ClientStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.ClientStreaming, context.Method);
+            try
+            {
+                var response = await continuation(
+                    new CountingStreamReader<TRequest>(requestStream, () => metrics.StreamMsgReceived(MethodType.ClientStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.ClientStreaming, context.Method, StatusCode.OK);
+                return response;
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.ClientStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.ClientStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.ServerStreaming, context.Method);
+            try
+            {
+                await continuation(request,
+                    new CountingStreamWriter<TResponse>(responseStream, () => metrics.StreamMsgSent(MethodType.ServerStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.ServerStreaming, context.Method, StatusCode.OK);
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.ServerStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.ServerStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+
+        public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            metrics.Started(MethodType.DuplexStreaming, context.Method);
+            try
+            {
+                await continuation(
+                    new CountingStreamReader<TRequest>(requestStream, () => metrics.StreamMsgReceived(MethodType.DuplexStreaming, context.Method)),
+                    new CountingStreamWriter<TResponse>(responseStream, () => metrics.StreamMsgSent(MethodType.DuplexStreaming, context.Method)),
+                    context);
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, StatusCode.OK);
+            }
+            catch (RpcException ex)
+            {
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, ex.StatusCode);
+                throw;
+            }
+            catch
+            {
+                metrics.Handled(MethodType.DuplexStreaming, context.Method, StatusCode.Internal);
+                throw;
+            }
+        }
+    }
+}

--- a/Nexogen.Libraries.Metrics.sln
+++ b/Nexogen.Libraries.Metrics.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nexogen.Libraries.Metrics.P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexogen.Libraries.Metrics.Prometheus.Standalone", "Nexogen.Libraries.Metrics.Prometheus.Standalone\Nexogen.Libraries.Metrics.Prometheus.Standalone.csproj", "{A45DC54A-663B-4FD1-96A7-8E485391B17C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexogen.Libraries.Metrics.Prometheus.Grpc", "Nexogen.Libraries.Metrics.Prometheus.Grpc\Nexogen.Libraries.Metrics.Prometheus.Grpc.csproj", "{ADEC23A2-888E-4AAA-B230-3C9AB5737FEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{A45DC54A-663B-4FD1-96A7-8E485391B17C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A45DC54A-663B-4FD1-96A7-8E485391B17C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A45DC54A-663B-4FD1-96A7-8E485391B17C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADEC23A2-888E-4AAA-B230-3C9AB5737FEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADEC23A2-888E-4AAA-B230-3C9AB5737FEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADEC23A2-888E-4AAA-B230-3C9AB5737FEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADEC23A2-888E-4AAA-B230-3C9AB5737FEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -157,3 +157,25 @@ or
 var metrics = new PrometheusMetrics();
 await new PrometheusServer(new PrometheusServerOptions {Port = 9100}, metrics, loggerFactory).StartAsync();
 ```
+
+## gRPC
+
+We provide gRPC interceptors for capturing metrics.
+
+```sh
+dotnet add package Nexogen.Libraries.Metrics.Prometheus.Grpc
+```
+
+For gRPC servers:
+
+```csharp
+services.AddSingleton<ServerMetrics>()
+        .AddGrpc(options => options.Interceptors.Add<ServerMetricsInterceptor>());
+```
+
+For gRPC clients:
+
+```csharp
+services.AddSingleton<ClientMetrics>()
+        .AddGrpcClient<T>((provider, options) => options.Interceptors.Add(new ClientMetricsInterceptor(provider.GetRequiredService<IMetrics>())));
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,7 @@ $BUILD ./Nexogen.Libraries.Metrics
 $BUILD ./Nexogen.Libraries.Metrics.Extensions
 $BUILD ./Nexogen.Libraries.Metrics.Prometheus
 $BUILD ./Nexogen.Libraries.Metrics.Prometheus.AspCore
+$BUILD ./Nexogen.Libraries.Metrics.Prometheus.Grpc
 $BUILD ./Nexogen.Libraries.Metrics.Prometheus.PushGateway
 $BUILD ./Nexogen.Libraries.Metrics.Prometheus.Standalone
 


### PR DESCRIPTION
This introduces a new package `Nexogen.Libraries.Metrics.Prometheus.Grpc` providing gRPC interceptors for capturing metrics.

The metrics are aligned with a roughly equivalent Go library: https://github.com/grpc-ecosystem/go-grpc-prometheus