### PR TITLE
Use a relative address so the base path is respected

### DIFF
--- a/Nexogen.Libraries.Metrics.Prometheus.PushGateway/PushGateway.cs
+++ b/Nexogen.Libraries.Metrics.Prometheus.PushGateway/PushGateway.cs
@@ -121,7 +121,7 @@ namespace Nexogen.Libraries.Metrics.Prometheus.PushGateway
 
         private HttpRequestMessage CreateRequestMessage(IExposable metrics, string job, Stream stream)
         {
-            var path = string.Format("/metrics/job/{0}", WebUtility.UrlEncode(job));
+            var path = string.Format("metrics/job/{0}", WebUtility.UrlEncode(job));
             
             if (!string.IsNullOrEmpty(instance))
             {


### PR DESCRIPTION
If we have a base URL like this:
http://services/pushgateway/ 

Then we need to pass a relative path for it to work with HttpClient.